### PR TITLE
Fix y drop location

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -180,8 +180,8 @@ Vue.component('room', {
       let dxy = JSON.parse(event.dataTransfer.getData('dxy'));
 
       let drop = {
-        x: (event.clientX - dxy[0]) * 100.0 / rect.width,
-        y: (event.clientY - dxy[1]) * 100.0 / rect.height
+        x: ((event.clientX - dxy[0]) / rect.width) * 100,
+        y: ((event.clientY - dxy[1]) / rect.height) * 90
       };
 
       let card = document.querySelector('[data-dragged=yes]');


### PR DESCRIPTION
When dragging and dropping the y coordinate is about 10% off, so I adjusted the calculation to 90% from 100 and it looks good. I would have kept digging more to find the exact reason why this is happening (probably a bounding box issue) but there are other much bigger features that should get focus. If this is a continuing issue I'll swing back around and dig deeper.

![](https://media.giphy.com/media/OA8OvqfmoZ5ug/giphy.gif))

